### PR TITLE
Add quick links to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 This is the public repository used for Email Markup Consortium planning and discussion.
 
+## Quick links
+
+- [Meeting notes](meeting-notes)
+- [New members guide](new-member-welcome.md)
+- [Glossary of terms](glossary.md)
+
 ## Slack
 
 The group is also gathering on the private #email-markup-consortium channel of the [Email Geeks Slack](https://email.geeks.chat/).


### PR DESCRIPTION
Adding quick links in the repo's readme. We're more put together at this point, and the repo should reflect that. Once the website is live, we can update the links if needed.

Once #24 is closed, we can also add a link to the mission.