### PR TITLE
Update description for content-issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/content-issue.md
+++ b/.github/ISSUE_TEMPLATE/content-issue.md
@@ -1,6 +1,6 @@
 ---
 name: Content Issue
-about: Only to be used when other templates don't cover the issue
+about: Flag, discuss or suggest an improvement for a content-related issue
 title: ''
 labels: content
 assignees: ''


### PR DESCRIPTION
The [content-issue template](https://github.com/email-markup-consortium/email-markup-consortium/blob/main/.github/ISSUE_TEMPLATE/content-issue.md) currently has the same description as [any-other-issue](https://github.com/email-markup-consortium/email-markup-consortium/blob/main/.github/ISSUE_TEMPLATE/any-other-issue.md). This PR updates the description of the template accodingly.